### PR TITLE
Two small things

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,6 @@ set(TCI_VERSION "${TCI_VERSION_RAW}")
 string(REPLACE "." ";" TCI_VERSION_RAW ${TCI_VERSION_RAW})
 list(GET TCI_VERSION_RAW 0 TCI_VERSION_MAJOR)
 list(GET TCI_VERSION_RAW 1 TCI_VERSION_MINOR)
-set(prefix ${CMAKE_INSTALL_PREFIX})
 
 project(TCI
     VERSION "${TCI_VERSION}"
@@ -21,6 +20,8 @@ include(CheckIncludeFile)
 include(CheckSymbolExists)
 include(CheckCSourceCompiles)
 include(CMakePackageConfigHelpers)
+
+set(prefix ${INSTALL_PREFIX})
 
 #
 # Set up options
@@ -439,7 +440,7 @@ set_property(TARGET tci-objects PROPERTY POSITION_INDEPENDENT_CODE 1)
 target_include_directories(tci-objects PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    $<INSTALL_INTERFACE:${INSTALL_INCLUDEDIR}>
 )
 
 if(TCI_CXX)
@@ -474,13 +475,13 @@ target_sources(${TCI_MAIN_TARGET}
 )
 
 install(TARGETS ${TCI_TARGETS} EXPORT tci-targets
-    FILE_SET headers DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILE_SET headers DESTINATION ${INSTALL_INCLUDEDIR}
 )
 
 install(EXPORT tci-targets
     FILE TCITargets.cmake
     NAMESPACE TCI::
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/TCI)
+    DESTINATION ${INSTALL_LIBDIR}/cmake/TCI)
 
 write_basic_package_version_file(
     "TCIConfigVersion.cmake"
@@ -488,6 +489,6 @@ write_basic_package_version_file(
     COMPATIBILITY AnyNewerVersion)
 
 install(FILES "TCIConfig.cmake" "${CMAKE_CURRENT_BINARY_DIR}/TCIConfigVersion.cmake"
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/TCI)
+    DESTINATION ${INSTALL_LIBDIR}/cmake/TCI)
 
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tci.pc" DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tci.pc" DESTINATION ${INSTALL_LIBDIR}/pkgconfig)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ project(TCI
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 include(ConfigureWrapper)
-include(CheckIncludefile)
+include(CheckIncludeFile)
 include(CheckSymbolExists)
 include(CheckCSourceCompiles)
 include(CMakePackageConfigHelpers)


### PR DESCRIPTION
Sorry to bother you with more build system nonsense! I needed to make the following two changes in order to build and install tci:
1. Fixed spelling of CheckIncludeFile (otherwise there is an error)
2. Replaced `CMAKE_INSTALL_LIBDIR` (previously defined by GNUInstallDirs) with `INSTALL_LIBDIR` from the ConfigureWrapper script. Same for `CMAKE_INSTALL_INCLUDEDIR`. Otherwise, CMake tries to install config files to `/cmake/TCI`

Then I could successfully do
```
cmake -B build -S . -DCMAKE_INSTALL_PREFIX=./installprefix
cmake --build build
cmake --install build
```